### PR TITLE
Replace FAT by ext2 for storage partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,13 @@ To write the partition table to the SD card and exit `fdisk`, type `w`.
 Next, execute
 ```
 sudo mkfs -t vfat -n ZYNQ_BOOT /dev/sdX1
-sudo mkfs -t vfat -n STORAGE   /dev/sdX2
 ```
-to create a new FAT filesystem on both partitions.
+to create a new FAT filesystem for the boot partition, and
+```
+sudo mkfs -t ext2 -L STORAGE /dev/sdX2
+```
+to create an ext2 filesystem for storage.  (Do not use FAT for storage because it does not support
+symlinks, which are needed to correctly install libraries.)
 
 ### Load boot images to SD card
 


### PR DESCRIPTION
FAT is not a suitable filesystem for the storage partition as it does not support symlinks, breaking our library install process.

I suggest to use ext2 instead, because it is well-supported by the Linux kernel, and, in contrast to ext3/4, is not a _journaling_ filesystem, meaning less wear on the SD card.