### PR TITLE
`HERO_CI` shallow clone integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+<!---
+[![Build Status](https://iis-jenkins.ee.ethz.ch/job/hero-sdk-pipeline/badge/icon)](https://iis-jenkins.ee.ethz.ch/job/hero-sdk-pipeline)
+-->
 # HERO Software Development Kit
 **HERO** \[[1](https://arxiv.org/abs/1712.06497)\], the open Heterogeneous Research Platform, combines a **PULP-based** \[[2](https://ieeexplore.ieee.org/document/7477325/)\] open-source parallel manycore accelerator implemented on FPGA with a hard ARM Cortex-A multicore host processor running full-stack Linux. HERO is the **first heterogeneous system architecture** that combines a powerful ARM multicore host with a highly parallel and scalable manycore accelerator based on a **RISC-V cores**.
 HERO offers a **complete hardware and software platform** which advances the state of the art of transparent accelerator programming using the **OpenMP v4.5 Accelerator Model**. The programmer can write a single application source file for the host and use OpenMP directives for parallelization and accelerator offloading. Lower-level details such as differing ISAs as well as **shared virtual memory (SVM)** \[[3](https://ieeexplore.ieee.org/document/7797491/)\] between host and accelerator are handled by our heterogeneous toolchain based on GCC 7 \[[4](https://dl.acm.org/citation.cfm?id=3079071)\], runtime libraries, kernel driver and our open-source hardware IPs.

--- a/hero-z-7045-builder
+++ b/hero-z-7045-builder
@@ -49,8 +49,8 @@ get_sources() {
     update_env
 
     cd ${HERO_TOOLCHAIN_DIR}
-    git submodule update --init --recursive
-
+    ./hero_arm_toolchain_builder -d
+    
     cd ${HERO_PULP_SDK_DIR}
     git submodule update --init --recursive
 
@@ -66,11 +66,15 @@ build_riscv32_toolchain() {
     update_env
 
     cd ${HERO_TOOLCHAIN_DIR}
-    ./hero_riscv32_toolchain_builder -dPj
+    ./hero_riscv32_toolchain_builder -Pj
 
     if [ $? -ne 0 ]; then
         echo "ERROR: build_riscv32_toolchain failed, aborting now."
         exit 1
+    fi
+
+    if [[ ! ${HERO_CI+x} ]]; then
+        ./hero_riscv32_toolchain_builder -x
     fi
 }
 
@@ -95,11 +99,15 @@ build_arm_toolchain() {
     prepare_linux
 
     cd ${HERO_TOOLCHAIN_DIR}
-    ./hero_arm_toolchain_builder -dPj
+    ./hero_arm_toolchain_builder -Pj
 
     if [ $? -ne 0 ]; then
         echo "ERROR: build_arm_toolchain failed, aborting now."
         exit 1
+    fi
+
+    if [[ -z "${HERO_CI}" ]]; then
+        ./hero_arm_toolchain_builder -x
     fi
 }
 
@@ -162,10 +170,18 @@ build_hero_toolchain() {
         exit 1
     fi
 
+    if [[ ! ${HERO_CI+x} ]]; then
+        ./hero_riscv32_toolchain_builder -x
+    fi
+
     ./hero_arm_toolchain_builder -gj
     if [ $? -ne 0 ]; then
         echo "ERROR: build_hero_toolchain failed for host, aborting now."
         exit 1
+    fi
+
+    if [[ ! ${HERO_CI+x} ]]; then
+        ./hero_arm_toolchain_builder -x
     fi
 
     # Build the HERO target library

--- a/jenkinsfile
+++ b/jenkinsfile
@@ -1,13 +1,3 @@
-void setBuildStatus(String message, String state) {
-  step([
-      $class: "GitHubCommitStatusSetter",
-      reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/pulp-platform/hero-sdk"],
-      contextSource: [$class: "ManuallyEnteredCommitContextSource", context: "ci/jenkins/build-status"],
-      errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
-      statusResultSource: [ $class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
-  ]);
-}
-
 pipeline {
     options {
         buildDiscarder(logRotator(numToKeepStr: '10', artifactNumToKeepStr: '10'))
@@ -20,23 +10,80 @@ pipeline {
         string(name: 'HERO_CI', defaultValue: '1')
     }
     stages {
-        stage('get_sources') {
+        stage('Checkout') {
             steps {
                 timeout(time: 10, unit: 'MINUTES') {
                     sh './hero-z-7045-builder -s'
                 }
             }
-            post {
-                unstable {
-                    mail to: 'alessandro.capotondi@unibo.it',
-                         subject: "Unstable: ${currentBuild.fullDisplayName}",
-                         body: "Something is wrong with ${env.BUILD_URL}: some tests were broken."
-                    setBuildStatus("Build failed", "FAILURE");
-                }
-                success {
-                    setBuildStatus("Build succeeded", "SUCCESS");
+        }
+        stage('Build PULP GCC (riscv32') {
+            steps {
+                timeout(time: 30, unit: 'MINUTES') {
+                    sh './hero-z-7045-builder -r'
                 }
             }
         }
+        stage('Build PULP SDK') {
+            steps {
+                timeout(time: 30, unit: 'MINUTES') {
+                    sh './hero-z-7045-builder -p'
+                }
+            }
+        }
+        stage('Build Host GCC (armv7') {
+            steps {
+                timeout(time: 30, unit: 'MINUTES') {
+                    sh './hero-z-7045-builder -a'
+                }
+            }
+        }
+        stage('Build Linux') {
+            steps {
+                timeout(time: 30, unit: 'MINUTES') {
+                    sh './hero-z-7045-builder -l'
+                }
+            }
+        }
+        stage('Build HERO libraries') {
+            steps {
+                timeout(time: 30, unit: 'MINUTES') {
+                    sh './hero-z-7045-builder -o'
+                }
+            }
+        }
+        stage('Build HERO GCC') {
+            steps {
+                timeout(time: 30, unit: 'MINUTES') {
+                    sh './hero-z-7045-builder -t'
+                }
+            }
+        }
+    }
+    post {
+        always {
+            cleanWs()
+        }
+        success {
+            echo 'This will run only if successful'
+        }
+        failure {
+            echo 'This will run only if failed'
+        }
+        unstable {
+            echo 'This will run only if the run was marked as unstable'
+        }
+        changed {
+            echo 'This will run only if the state of the Pipeline has changed'
+            echo 'For example, if the Pipeline was previously failing but is now successful'
+        }
+/*************        
+        unstable {
+            githubNotify account: 'alessandrocapotondi', context: 'Checkout', credentialsId: 'jenkins', description: '', gitApiUrl: '', repo: '***', sha: "${env.GIT_COMMIT}", status: 'FAILURE', targetUrl: "${env.BUILD_URL}"
+        }
+        success {
+            githubNotify account: 'alessandrocapotondi', context: 'Checkout', credentialsId: 'jenkins', description: '', gitApiUrl: '', repo: '***', sha: "${env.GIT_COMMIT}", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}"
+        }
+*************/
     }
 }

--- a/jenkinsfile
+++ b/jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
         label 'hero_sdk'
     }
     parameters {
-        string(name: 'HERO_MAX_PARALLEL_BUILD_JOBS', defaultValue: '12')
+        string(name: 'HERO_MAX_PARALLEL_BUILD_JOBS', defaultValue: '24')
         string(name: 'HERO_CI', defaultValue: '1')
     }
     stages {

--- a/jenkinsfile
+++ b/jenkinsfile
@@ -1,0 +1,42 @@
+void setBuildStatus(String message, String state) {
+  step([
+      $class: "GitHubCommitStatusSetter",
+      reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/pulp-platform/hero-sdk"],
+      contextSource: [$class: "ManuallyEnteredCommitContextSource", context: "ci/jenkins/build-status"],
+      errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
+      statusResultSource: [ $class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
+  ]);
+}
+
+pipeline {
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '10', artifactNumToKeepStr: '10'))
+    }
+    agent { 
+        label 'hero_sdk'
+    }
+    parameters {
+        string(name: 'HERO_MAX_PARALLEL_BUILD_JOBS', defaultValue: '12')
+        string(name: 'HERO_CI', defaultValue: '1')
+    }
+    stages {
+        stage('get_sources') {
+            steps {
+                timeout(time: 10, unit: 'MINUTES') {
+                    sh './hero-z-7045-builder -s'
+                }
+            }
+            post {
+                unstable {
+                    mail to: 'alessandro.capotondi@unibo.it',
+                         subject: "Unstable: ${currentBuild.fullDisplayName}",
+                         body: "Something is wrong with ${env.BUILD_URL}: some tests were broken."
+                    setBuildStatus("Build failed", "FAILURE");
+                }
+                success {
+                    setBuildStatus("Build succeeded", "SUCCESS");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Dear @accuminium,
this patch integrates on the shallow clone for the submodules included inside `hero-gcc-toolchain`.

## Modifications
i.  Add shallow clone for `hero-gcc-toolchain` when `HERO_CI` is set. (Fix #24)
ii. Clean after installation on every GCC build stage when `HERO_CI` is set.

Now is not anymore necessary to use any `git submodule` command from the root folder of `hero-sdk`. Everything is done within the builder script. When `HERO_CI` environmental variable is set the script clone the submodules shallowly otherwise it get them regularly.

I also added a new CI task on our Jenkins server that uses the Jenkins Pipeline. The pipeline controls all the builder targets one-by-one:
https://iis-jenkins.ee.ethz.ch/view/hero-sdk/job/hero-sdk-pipeline/

Here the old CI task that control the `-A` build flow:
https://iis-jenkins.ee.ethz.ch/view/hero-sdk/job/hero-sdk-centos7/

I also tried to integrate such modifications on you `travis` branch to see if it fix the problem of memory footprint. Here the branch https://github.com/pulp-platform/hero-sdk/tree/travis-dev-integration.

Here the build (still going)
https://travis-ci.org/pulp-platform/hero-sdk/builds/441381805?utm_source=github_status&utm_medium=notification

I think, anyway, that travis at the moment is anyway too slow.